### PR TITLE
Validating VCL Functions in Conditions And Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ target
 /.project
 /.settings
 /RUNNING_PID
+
+# vim swap files
+*sw*
+
+# jenv
+.java-version
+

--- a/app/com/iheart/controllers/VclController.scala
+++ b/app/com/iheart/controllers/VclController.scala
@@ -44,9 +44,10 @@ class VclController extends Controller with BaseController {
   def config = Action.async { implicit request =>
     val nvConditions = VclConfigCondition.nameValueConditions
     val svConditions = VclConfigCondition.singleValConditions
+    val boolConditions = VclConfigCondition.boolConditions
     val actions = VclConfigAction.actionMap
 
-    Future { Ok(Json.toJson(ConfigResponse(nvConditions,svConditions,actions))) }
+    Future { Ok(Json.toJson(ConfigResponse(nvConditions,svConditions,boolConditions,actions))) }
   }
 
 

--- a/app/com/iheart/json/Formats.scala
+++ b/app/com/iheart/json/Formats.scala
@@ -19,8 +19,8 @@ object Formats {
 
   implicit val ruleConditionFormat: Reads[Either[RuleError,RuleCondition]] = (
     ( JsPath \ "condition").read[String] and
-    (JsPath \ "matcher").read[String] and
-      (JsPath \ "value").read[String] and
+    (JsPath \ "matcher").readNullable[String] and
+      (JsPath \ "value").readNullable[String] and
       (JsPath \ "name").readNullable[String]
     )(RuleCondition.build _)
 
@@ -76,6 +76,7 @@ object Formats {
 
   case class ConfigResponse(nameValueConditions: Map[String,VclCondition],
                             singleValueConditions: Map[String,VclCondition],
+                            boolConditions: Map[String,VclCondition],
                             actions: Map[String, VclAction])
 
   implicit val vclCondTypeWrites: Writes[VclConditionType] = new Writes[VclConditionType] {
@@ -120,9 +121,10 @@ object Formats {
     def writes(cr: ConfigResponse): JsValue = {
       val nvc = cr.nameValueConditions.map( (nv) => Json.toJson(nv._2))
       val svc = cr.singleValueConditions.map( (sv) => Json.toJson(sv._2))
+      val bvc = cr.boolConditions.map( (sv) => Json.toJson(sv._2))
       val actions = cr.actions.map( a => Json.toJson( a._2))
       val matchers = vclMatcherMap.map( v => Json.obj("key" -> v._1, "label" -> v._2._2))
-      Json.obj("conditions" -> svc.++(nvc), "actions" -> actions, "vcl_matchers" -> matchers)
+      Json.obj("conditions" -> svc.++(nvc).++(bvc), "actions" -> actions, "vcl_matchers" -> matchers)
     }
 
   }

--- a/app/com/iheart/json/Formats.scala
+++ b/app/com/iheart/json/Formats.scala
@@ -104,7 +104,7 @@ object Formats {
       Json.obj("key" -> a.key,
                "label" -> a.label,
                "action_type" -> a.actionType,
-               "vcl_functions" -> a.vclFunctions)
+               "vcl_functions" -> a.validVclFunctions)
     }
   }
 

--- a/app/com/iheart/models/ModelHelpers.scala
+++ b/app/com/iheart/models/ModelHelpers.scala
@@ -1,5 +1,9 @@
 package com.iheart.models
 
+import com.iheart.models.VclConfigCondition._
+import com.iheart.util.VclUtils.VclConditionType._
+import play.Logger
+
 import scala.util.matching.Regex
 
 
@@ -16,6 +20,10 @@ trait ModelHelpers {
     case false => Seq()
   }
 
+  def needsMatcher(key: String): Boolean = {
+    conditionMap.get(key).isDefined &&
+      conditionMap(key).conditionType != BoolCond
+  }
   object RegexUtils {
     class RichRegex(underlying: Regex) {
       def matches(s: String) = underlying.pattern.matcher(s).matches

--- a/app/com/iheart/models/ModelValidations.scala
+++ b/app/com/iheart/models/ModelValidations.scala
@@ -47,8 +47,9 @@ trait ModelValidations extends ModelHelpers {
     (conditions.count(c => c.condition.conditionType == NameValCond && (c.name.isEmpty || c.value.isEmpty)) == 0).toValidate("NameVal conditions must have name and value")
 
   //Make sure we used a valid matcher
-  def validMatcher(key: String): Validation =
-    vclMatcherMap.get(key).isDefined.toValidate("Invalid matcher " + key + " specified")
+  def validMatcher(condition: String, matcher: String): Validation = {
+    (!(needsMatcher(condition) && vclMatcherMap.get(matcher).isEmpty)).toValidate("Invalid matcher " + matcher + " specified")
+  }
 
   //Make sure this matcher can be used for this Condition
   def validMatcherForCondition(key: String, m: String) = {

--- a/app/com/iheart/models/Rule.scala
+++ b/app/com/iheart/models/Rule.scala
@@ -22,7 +22,7 @@ case class Rule(conditions: Seq[RuleCondition],
   
   def toConfigCondition(str: String) = conditionMap(str)
 
-  def actionHasVclFunction(func: VclFunctionType): Boolean = actions.count(a => a.action.vclFunctions.contains(func)) > 0
+  def actionHasVclFunction(func: VclFunctionType): Boolean = actions.count(a => a.action.validVclFunctions.contains(func)) > 0
 
 }
 
@@ -44,7 +44,8 @@ object Rule extends ModelValidations {
                   validateSingleAction(actions.map(_.right.get)),
                   validateNameValAction(actions.map(_.right.get)),
                   validateNameValCondition(conditions.map(_.right.get)),
-                  validateValAction(actions.map(_.right.get))) ) match {
+                  validateValAction(actions.map(_.right.get)),
+                  validateVclFunctions(conditions.map(_.right.get),actions.map(_.right.get) )) ) match {
         case Left(x) => Logger.info("error with rule: " + x.toString()); Left(RuleError(x))
         case Right(y) => Right (Rule(conditions.map (_.right.get), actions.map (_.right.get), VclMatchType.fromString(matchType), index) )
       }

--- a/app/com/iheart/models/RuleCondition.scala
+++ b/app/com/iheart/models/RuleCondition.scala
@@ -10,12 +10,12 @@ case class RuleCondition(condition: VclCondition, matcher: Option[VclMatchers], 
 
 object RuleCondition extends ModelValidations {
   def apply(key: String, matcher: String, value: String, name: Option[String]): Either[RuleError,RuleCondition] = {
-    isValid(Seq(validCondition(key),validMatcher(matcher),validAcl(key,value))) match {
+    isValid(Seq(validCondition(key),validMatcher(key,matcher),validAcl(key,value))) match {
       case Left(x) => Logger.info("Error: " + x); Left(RuleError(x))
       case Right(y) =>  Right(RuleCondition(conditionMap(key), vclMatcherMap.get(matcher).map(_._1), value, name))
     }
   }
 
-  def build(key: String, matcher: String, value: String, name: Option[String]) =
-     apply(key,matcher,value,name)
+  def build(key: String, matcher: Option[String], value: Option[String], name: Option[String]) =
+     apply(key,matcher.getOrElse(""),value.getOrElse(""),name)
 }

--- a/app/com/iheart/models/VclConfigAction.scala
+++ b/app/com/iheart/models/VclConfigAction.scala
@@ -5,19 +5,19 @@ import com.iheart.util.VclUtils.VclFunctionType._
 
 
 case class VclAction(key: String, label: String, actionType: VclActionType,
-                     vclFunctions: Seq[VclFunctionType] )
+                     validVclFunctions: Seq[VclFunctionType] )
 
 object VclConfigAction {
 
-  val doNotCache = VclAction("do_not_cache","Do Not Cache", Bool,Seq(vclBackendResp))
-  val setTTL = VclAction("set_ttl","Cache For", Units, Seq(vclBackendResp) )
-  val httpRedirect = VclAction("http_redirect","HTTP Redirect to", SingleAction,  Seq(vclRecv))
+  val doNotCache = VclAction("do_not_cache","Do Not Cache", Bool,Seq(vclBackendResp, vclHit))
+  val setTTL = VclAction("set_ttl","Cache For", Units, Seq(vclBackendResp,vclHit) )
+  val httpRedirect = VclAction("http_redirect","HTTP Redirect to", SingleAction,  Seq(vclRecv,vclBackendResp,vclDeliver))
   val addCookie = VclAction("add_cookie","Add Cookie", NameValAction, Seq(vclDeliver) )
   val remCookies = VclAction("remove_cookie","Remove Cookies", Bool, Seq(vclRecv, vclBackendResp) )
-  val denyRequest = VclAction("deny_request","Deny Request", Bool, Seq(vclRecv))
-  val removeReqHeader = VclAction("remove_request_header","Remove Request Header", ValAction, Seq(vclRecv))
+  val denyRequest = VclAction("deny_request","Deny Request", Bool, Seq(vclRecv, vclBackendResp))
+  val removeReqHeader = VclAction("remove_request_header","Remove Request Header", ValAction, Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
   val removeRespHeader = VclAction("remove_response_header","Remove Response Header", ValAction, Seq(vclBackendResp))
-  val addReqHeader = VclAction("add_request_header","Add Request Header", NameValAction, Seq(vclRecv))
+  val addReqHeader = VclAction("add_request_header","Add Request Header", NameValAction, Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
   val addRespHeader = VclAction("add_response_header","Add Response Header", NameValAction, Seq(vclDeliver))
   val setBackend = VclAction("set_backend","Set backend", ValAction,Seq(vclRecv))
 

--- a/app/com/iheart/models/VclConfigCondition.scala
+++ b/app/com/iheart/models/VclConfigCondition.scala
@@ -1,24 +1,27 @@
 package com.iheart.models
 
 import com.iheart.util.VclUtils.VclConditionType._
+import com.iheart.util.VclUtils.VclFunctionType.VclFunctionType
+import com.iheart.util.VclUtils.VclFunctionType._
 import com.iheart.util.VclUtils.VclMatchers._
 
 
 case class VclCondition( key: String,
                          label: String,
                         conditionType: VclConditionType,
-                        vclMatchers: Seq[VclMatchers] )
+                        vclMatchers: Seq[VclMatchers] ,
+                        validVclFunctions: Seq[VclFunctionType] )
 
 object VclConfigCondition {
 
-  val requestUrl = VclCondition("request_url","Request Url", ValCond,Seq(Equals,DoesNotEqual,Matches,DoesNotMatch))
-  val contentType = VclCondition("content_type","Content Type", ValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch))
-  val clientIp = VclCondition("client_ip","Client IP/Network", ValCond, Seq(Matches, DoesNotMatch))
-  val requestParam = VclCondition("request_param","Request Parameter", NameValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch))
-  val clientCookie = VclCondition("cookie","Cookie", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual))
-  val requestHeader = VclCondition("request_header","Request header", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual))
-  val fileExtension = VclCondition("file_extension", "File Extension", ValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch))
-  val isCached = VclCondition("is_cached", "is Cached", BoolCond, Seq() )
+  val requestUrl = VclCondition("request_url","Request Url", ValCond,Seq(Equals,DoesNotEqual,Matches,DoesNotMatch), Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
+  val contentType = VclCondition("content_type","Content Type", ValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch),Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
+  val clientIp = VclCondition("client_ip","Client IP/Network", ValCond, Seq(Matches, DoesNotMatch), Seq(vclRecv))
+  val requestParam = VclCondition("request_param","Request Parameter", NameValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch), Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
+  val clientCookie = VclCondition("cookie","Cookie", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual), Seq(vclRecv,vclBackendResp))
+  val requestHeader = VclCondition("request_header","Request header", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual), Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
+  val fileExtension = VclCondition("file_extension", "File Extension", ValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch), Seq(vclRecv,vclBackendResp,vclDeliver,vclHit))
+  val isCached = VclCondition("is_cached", "is Cached", BoolCond, Seq(), Seq(vclHit) )
 
   val conditionMap = Map(
     "request_url" -> requestUrl,

--- a/app/com/iheart/models/VclConfigCondition.scala
+++ b/app/com/iheart/models/VclConfigCondition.scala
@@ -18,6 +18,7 @@ object VclConfigCondition {
   val clientCookie = VclCondition("cookie","Cookie", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual))
   val requestHeader = VclCondition("request_header","Request header", NameValCond, Seq(Matches,DoesNotMatch,Equals,DoesNotEqual))
   val fileExtension = VclCondition("file_extension", "File Extension", ValCond, Seq(Equals,DoesNotEqual,Matches,DoesNotMatch))
+  val isCached = VclCondition("is_cached", "is Cached", BoolCond, Seq() )
 
   val conditionMap = Map(
     "request_url" -> requestUrl,
@@ -26,8 +27,10 @@ object VclConfigCondition {
     "request_param" -> requestParam,
     "cookie" -> clientCookie,
     "request_header" -> requestHeader,
-    "file_extension" -> fileExtension )
+    "file_extension" -> fileExtension ,
+    "is_cached" -> isCached )
 
   val singleValConditions = conditionMap.filter(x => x._2.conditionType == ValCond)
   val nameValueConditions = conditionMap.filter(x => x._2.conditionType == NameValCond)
+  val boolConditions = conditionMap.filter(x => x._2.conditionType == BoolCond)
 }

--- a/app/com/iheart/util/VclUtils.scala
+++ b/app/com/iheart/util/VclUtils.scala
@@ -30,7 +30,7 @@ object VclUtils {
 
   object VclConditionType extends Enumeration {
     type VclConditionType = Value
-    val ValCond, NameValCond, Dropdown = Value
+    val ValCond, NameValCond, Dropdown, BoolCond = Value
   }
 
   object VclMatchers extends Enumeration {

--- a/app/com/iheart/vcl/VclGenerator.scala
+++ b/app/com/iheart/vcl/VclGenerator.scala
@@ -30,7 +30,7 @@ class VclGenerator extends VCLHelpers {
   }
 
   def parseGlobalRules(ruleset: String, rules: Seq[Rule]) = {
-    val funcs = List(vclBackendResp,vclRecv,vclDeliver)
+    val funcs = List(vclBackendResp,vclRecv,vclDeliver, vclHit)
 
     funcs.foreach { vclfunc =>
       globalConfig += "sub ruleset_" + ruleset +  "_global_" + vclfunc.toString + " { \n"

--- a/app/com/iheart/vcl/VclGenerator.scala
+++ b/app/com/iheart/vcl/VclGenerator.scala
@@ -11,7 +11,7 @@ class VclGenerator extends VCLHelpers {
 
 
   def parseGlobalRule(rule: Rule, vclFunction: VclFunctionType) = {
-    val actions = rule.actions.filter(a => a.action.vclFunctions.contains(vclFunction)).map { action =>
+    val actions = rule.actions.filter(a => a.action.validVclFunctions.contains(vclFunction)).map { action =>
       vclAction(action,vclFunction)
     }
 
@@ -71,7 +71,11 @@ class VclGenerator extends VCLHelpers {
   //  }
 
   def parseOrderedRules(ruleset: String, rules: Seq[Rule]) = {
-    val funcs = List(vclBackendResp,vclRecv,vclDeliver)
+    //val funcs = List(vclBackendResp,vclRecv,vclDeliver, vclHit)
+    val funcs: Seq[VclFunctionType] =
+      rules.flatMap(r => r.actions.map(a => a.action.validVclFunctions)).flatten intersect
+       rules.flatMap(r => r.conditions.map(c => c.condition.validVclFunctions)).flatten
+
     funcs.map { vclfunc =>
       globalConfig += "sub ruleset_" + ruleset + "_ordered_" + vclfunc + " { \n"
       rules.filter(_.actionHasVclFunction(vclfunc)).sortBy(_.index).zipWithIndex.foreach { case (rule,idx) =>

--- a/app/com/iheart/vcl/VclHelpers.scala
+++ b/app/com/iheart/vcl/VclHelpers.scala
@@ -117,11 +117,16 @@ trait VCLHelpers {
       case _ => "resp"
     }
 
+    val ttl = vclFunction match {
+      case VclFunctionType.vclHit => "obj.ttl"
+      case _ => "bereq.ttl"
+    }
+
     val actionStr = ruleaction.action match  {
       case VclConfigAction.doNotCache =>
         "set beresp.ttl = 0s; "
       case VclConfigAction.setTTL =>
-       s"""set beresp.ttl = ${ruleaction.value.get}${toTTL(ruleaction.units.getOrElse(VclUnits.SECONDS))};"""
+       s"""set ${ttl} = ${ruleaction.value.get}${toTTL(ruleaction.units.getOrElse(VclUnits.SECONDS))};"""
       case VclConfigAction.httpRedirect =>
         s"""return(synth(799,"${ruleaction.value.get}"));"""
       case VclConfigAction.denyRequest =>

--- a/app/com/iheart/vcl/VclHelpers.scala
+++ b/app/com/iheart/vcl/VclHelpers.scala
@@ -23,6 +23,7 @@ trait VCLHelpers {
   var vclDeliverStr: String = ""
   var vclRecvStr: String = ""
   var vclErrorStr: String = ""
+  var vclHitStr: String = ""
 
 
   //***************************************************************************
@@ -44,10 +45,11 @@ trait VCLHelpers {
   }
 
   def addToVcl(str: String, vclFunc: VclFunctionType) = vclFunc match {
-    case VclFunctionType.`vclBackendResp` => vclBackendRespStr += str
+    case VclFunctionType.vclBackendResp => vclBackendRespStr += str
     case VclFunctionType.vclRecv => vclRecvStr += str
     case VclFunctionType.vclDeliver => vclDeliverStr += str
     case VclFunctionType.vclError => vclErrorStr += str
+    case VclFunctionType.vclHit => vclHitStr += str
   }
 
   def generateAcl(rules: Seq[Rule]) = {
@@ -193,6 +195,8 @@ trait VCLHelpers {
       " ( " + opToText("bereq.http.ext", rulecondition.matcher.get, rulecondition.value) + " ) "
     case VclConfigCondition.fileExtension =>
       " ( " + opToText("req.http.ext", rulecondition.matcher.get, rulecondition.value) + " ) "
+    case VclConfigCondition.isCached =>
+      " ( obj.ttl > 0 ) "
   }
 
 
@@ -201,7 +205,7 @@ trait VCLHelpers {
  // ****************************************************
 
   def generateHostConditions(hostnames: Seq[Hostname], ruleset: String) = {
-    val funcs = List(vclBackendResp, vclRecv, vclDeliver)
+    val funcs = List(vclBackendResp, vclRecv, vclDeliver, vclHit)
 
     funcs.foreach { vclfunc =>
       var block = "\n"
@@ -298,6 +302,15 @@ trait VCLHelpers {
       |     set req.http.ext = regsub( req.http.ext, ".+\\.([a-zA-Z0-9]+)$", "\\1" );
       |
     """.stripMargin
+
+  vclHitStr =
+     """
+       |#--------------------------
+       |# VCL_HIT
+       |#--------------------------
+       |sub vcl_hit {
+       |
+     """.stripMargin
 
   vclErrorStr =
     """

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
 resolvers += Resolver.jcenterRepo
 

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -30,7 +30,7 @@
         <div class="container">
           <div class="navbar-header">
             <a class="navbar-brand" href="#/">Vcl Genie</a>
-            <a href="https://github.com/iheartradio/vclgenie"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
+            <a href="https://github.com/iheartradio/vclgeniedf"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
           </div>
         </div>
       </div>

--- a/frontend/app/scripts/controllers/main.js
+++ b/frontend/app/scripts/controllers/main.js
@@ -71,13 +71,33 @@ angular.module('vclgenie').controller('MainCtrl', ['$scope','$http','Api', funct
   //---------------------------------
   // View conditions
   //---------------------------------
-  $scope.isNameValCond = function(cond) {
+  $scope.showNameCond = function(cond) {
     var c = getConditionByKey(cond); 
 
     if (c != undefined && c.condition_type == 'NameValCond') 
       return true ;
     else 
       return false; 
+  }
+
+  $scope.showValCond = function(cond) {
+    var c = getConditionByKey(cond); 
+
+    console.log("Checking condition:"); console.log(c);
+
+    if (c != undefined && c.condition_type != 'BoolCond' ) 
+      return true ;
+    else 
+      return false; 
+  }
+
+  $scope.showMatchCond = function(cond) {
+    var c = getConditionByKey(cond); 
+
+    if (c != undefined && c.condition_type != 'BoolCond') 
+      return true ; 
+    else 
+      return false ; 
   }
 
   $scope.isNameValAction = function(cond) {
@@ -171,7 +191,16 @@ angular.module('vclgenie').controller('MainCtrl', ['$scope','$http','Api', funct
 
   $scope.conditionToText = function(c) {
     var cond = getConditionByKey(c); 
-    return cond.label; 
+    var str = '' ;
+
+    str = str + cond.label ; 
+    if (cond.condition_type == 'NameValCond')
+      str = str + ' ' + cond.name ; 
+
+    if (cond.condition_type == 'NameValCond' || cond.condition_type == 'ValCond')
+      str = str + matcherToText(cond.matcher) + ' ' + cond.value ; 
+
+    return str ; 
   }
 
   $scope.matcherToText = function(matcher) {

--- a/frontend/app/views/main.html
+++ b/frontend/app/views/main.html
@@ -54,7 +54,7 @@
       </div>
 
 
-      <span ng-if="isNameValCond(globalrule.conditions[$index].condition)">
+      <span ng-if="showNameCond(globalrule.conditions[$index].condition)">
         <div class="form-group">
         <label class="control-label col-sm-2">Name  </label> 
         <div class="col-sm-10">
@@ -63,7 +63,7 @@
        </div>
       </span>
 
-      <span ng-if="currentGlobalCondition">
+      <span ng-if="currentGlobalCondition && showValCond(globalrule.conditions[$index].condition)">
       <div class="form-group">
          <label class="control-label  col-sm-2">Match Type</label> 
          <div class="col-sm-10">
@@ -75,7 +75,7 @@
       </span>
 
 
-      <span ng-if="currentGlobalCondition"> 
+      <span ng-if="currentGlobalCondition && showMatchCond(globalrule.conditions[$index].condition)"> 
        <div class="form-group">
         <label class="control-label col-sm-2">Value</label> 
         <div class="col-sm-10">
@@ -169,7 +169,7 @@
         <div style="background: #e7e7e7; padding: 20px;">
            Match: {{rule.match_type | uppercase}} Conditions<br/>
            <br/><div ng-repeat="c in rule.conditions">
-            {{conditionToText(c.condition)}} {{c.name}} {{matcherToText(c.matcher)}} {{c.value}}
+            {{conditionToText(c.condition)}}
           </div>
           <br/><div ng-repeat="a in rule.actions">
             {{actionToText(a.action)}} {{a.name}} {{a.value}} {{a.units}}
@@ -219,7 +219,7 @@
                </div>
 
 
-               <span ng-if="isNameValCond(orderedrule.conditions[$index].condition)">
+               <span ng-if="showNameCond(orderedrule.conditions[$index].condition)">
                 <div class="form-group">
                   <label class="control-label col-sm-2">Name  </label> 
                   <div class="col-sm-10">
@@ -328,15 +328,6 @@
 
 
 
-
-
-
-
-
-
-
-
-
      </div>
 
      <div class="col-md-6">  
@@ -345,7 +336,7 @@
               <div as-sortable-item-handle class="as-sortable-item-handle" style="background: #e7e7e7; padding: 20px;">
                  Match: {{rule.match_type | uppercase}} Conditions<br/>
                  <br/><div ng-repeat="c in rule.conditions">
-                  {{conditionToText(c.condition)}} {{c.name}} {{matcherToText(c.matcher)}} {{c.value}}
+                  {{conditionToText(c.condition)}} 
                 </div>
                 <br/><div ng-repeat="a in rule.actions">
                   {{actionToText(a.action)}} {{a.name}} {{a.value}} {{a.units}}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
 // web plugins
 

--- a/test/JsonData.scala
+++ b/test/JsonData.scala
@@ -360,4 +360,51 @@ trait JsonData {
                               }""")
 
 
+ val  ruleJson9 = Json.parse("""{
+                                  "ordered_rules" :
+                                      [
+                                         {
+                                          "conditions" : [ { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue", "name" : "somename" },
+                                                           { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue2", "name" : "somename2"},
+                                                           { "condition" : "request_url", "matcher" : "matches", "value" : "/cookieurl"},
+                                                           { "condition" : "is_cached"  }
+                                                         ],
+                                         "actions" : [
+                                           { "action" : "remove_cookies", "value" : "somecookie" }
+                                                      ],
+                                          "match_type" : "ANY",
+                                          "index" : 2
+                                        },
+
+                                      {
+                                          "conditions" : [ { "condition" : "request_url", "matcher" : "matches", "value" : "/home" },
+                                                           { "condition" : "request_header", "matcher" : "matches", "value" : "someheadervalue", "name" : "X-HTTP-Something"}],
+                                          "actions" : [ { "action" : "set_ttl", "value" : "300", "units" : "SECONDS" },
+                                                        { "action" : "set_backend", "value" : "backend1" }
+                                                      ],
+                                          "match_type" : "ANY",
+                                          "index" : 1
+                                        }
+                                      ],
+
+                                  "global_rules" : [
+                                       {
+                                          "conditions" : [ { "condition" : "request_header", "matcher" : "equals", "value" : "globalvalue", "name" : "X-HTTP-Test" },
+                                                           { "condition" : "request_url", "matcher" : "matches", "value" : "/redirecter"}
+                                                         ],
+                                          "actions" : [ { "action" : "remove_request_header", "value" : "X-HTTP-Header"  } ],
+                                          "match_type" : "ALL"
+
+                                        }
+                                      ],
+
+                                "hostnames" :
+                                     [ { "hostname" : "www.yahoo.com" }, { "hostname" : "www.microsoft.com" }] ,
+
+                                "backends" : [ { "name" : "backend1" , "host" : "www.myhost.com", "host_header" : "www.myhost.com"} ]
+
+                              }""")
+
+
+
 }

--- a/test/JsonData.scala
+++ b/test/JsonData.scala
@@ -8,8 +8,7 @@ trait JsonData {
                                          {
                                           "conditions" : [ { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue", "name" : "somename" },
                                                            { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue2", "name" : "somename2"},
-                                                           { "condition" : "request_url", "matcher" : "matches", "value" : "/cookieurl"},
-                                                           { "condition" : "client_ip" , "matcher" : "matches", "value" : "3.3.3.3" }
+                                                           { "condition" : "request_url", "matcher" : "matches", "value" : "/cookieurl"}
                                                          ],
                                          "actions" : [ { "action" : "set_ttl", "value" : "600", "units" : "SECONDS" }
                                                       ],
@@ -364,13 +363,11 @@ trait JsonData {
                                   "ordered_rules" :
                                       [
                                          {
-                                          "conditions" : [ { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue", "name" : "somename" },
-                                                           { "condition" : "cookie", "matcher" : "matches", "value" : "somevalue2", "name" : "somename2"},
-                                                           { "condition" : "request_url", "matcher" : "matches", "value" : "/cookieurl"},
+                                          "conditions" : [
                                                            { "condition" : "is_cached"  }
                                                          ],
                                          "actions" : [
-                                           { "action" : "remove_cookies", "value" : "somecookie" }
+                                           { "action" : "set_ttl", "value" : "300" }
                                                       ],
                                           "match_type" : "ANY",
                                           "index" : 2
@@ -396,6 +393,33 @@ trait JsonData {
                                           "match_type" : "ALL"
 
                                         }
+                                      ],
+
+                                "hostnames" :
+                                     [ { "hostname" : "www.yahoo.com" }, { "hostname" : "www.microsoft.com" }] ,
+
+                                "backends" : [ { "name" : "backend1" , "host" : "www.myhost.com", "host_header" : "www.myhost.com"} ]
+
+                              }""")
+
+
+  val  ruleJson10 = Json.parse("""{
+                                  "ordered_rules" :
+                                      [
+                                         {
+                                          "conditions" : [
+                                                           { "condition" : "is_cached"  }
+                                                         ],
+                                         "actions" : [
+                                           { "action" : "add_cookie", "name" : "cachecookie", "value" : "somecookievalue" }
+                                                      ],
+                                          "match_type" : "ANY",
+                                          "index" : 1
+                                        }
+                                      ],
+
+                                  "global_rules" : [
+
                                       ],
 
                                 "hostnames" :

--- a/test/VclControllerSpec.scala
+++ b/test/VclControllerSpec.scala
@@ -67,6 +67,13 @@ class VclControllerSpec extends Specification with JsonData {
       bodyText must not contain("error")
     }
 
+    "not allow me to use an action that is not a valid condition" in new WithApplication {
+      val Some(result) = route(FakeRequest(POST,"/vcl").withJsonBody(ruleJson10))
+      status(result) must equalTo(BAD_REQUEST)
+      val bodyText = contentAsString(result)
+      bodyText must contain("Sorry you mixed conditions and actions that can not be used")
+    }
+
 
   }
 }

--- a/test/VclControllerSpec.scala
+++ b/test/VclControllerSpec.scala
@@ -60,6 +60,13 @@ class VclControllerSpec extends Specification with JsonData {
       bodyText must contain("Invalid backend name specified")
     }
 
+    "allow me to use a boolean condition is_cached" in new WithApplication {
+      val Some(result) = route(FakeRequest(POST,"/vcl").withJsonBody(ruleJson9))
+     // status(result) must equalTo(OK)
+      val bodyText = contentAsString(result)
+      bodyText must not contain("error")
+    }
+
 
   }
 }


### PR DESCRIPTION
There is an issue where the object you want to use in a condition is not available in the vcl function you want to use as an action.

E.g., check to see if an object is cached, is only available in vcl_hit, but an action that requires resp header, would not be available.

Added the functions where a condition and an action would be valid and then intersect the two to ensure we come out with at least one function :) 